### PR TITLE
Fix RuntimeError

### DIFF
--- a/siibra_explorer_toolsuite/__init__.py
+++ b/siibra_explorer_toolsuite/__init__.py
@@ -76,7 +76,7 @@ def run(atlas: Atlas, space: Space, parc: Parcellation, region: Optional[Region]
     return_url=f'{return_url}/rn:{get_hash(region.name)}'
 
     try:
-        result_props=region.spatial_props(space)
+        result_props=region.spatial_props(space, maptype='statistical')
         if len(result_props.components) == 0:
             return return_url + nav_string.format(encoded_nav='0.0.0', **zoom_kwargs)
     except Exception as e:


### PR DESCRIPTION
Dear Xiao,
I was just testing my recent implementation of voluba-mriwarp and got an error from siibra-explorer-toolsuite.

```
import siibra
import siibra_explorer_toolsuite

siibra_explorer_toolsuite.run(siibra.atlases['human'], siibra.spaces['mni152'], siibra.parcellations['julich 3.0'], siibra.get_region('julich 3.0', 'acbl left'))

[out]: RuntimeError: Cannot build mask for AcbL (Lateral Accumbens, Ventral Striatum) left from MapType.LABELLED maps in Space: MNI 152 ICBM 2009c Nonlinear Asymmetric
```

Changing line 79 in `__init__.py` from `result_props=region.spatial_props(space)` to `result_props=region.spatial_props(space, maptype='statistical')` resolves the problem. Would that make sense?